### PR TITLE
chore: add buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const { Buffer } = require('buffer')
 const endable = require('./endable')
 
 module.exports = (stream, goodbye) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -28,6 +33,15 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "concat-map": {
@@ -143,6 +157,11 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "inflight": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "type": "git",
     "url": "git://github.com/alanshaw/it-goodbye.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "buffer": "^5.6.0"
+  },
   "devDependencies": {
     "async-iterator-to-pull-stream": "^1.3.0",
     "muxrpc": "^6.4.2",


### PR DESCRIPTION
This PR adds buffer as a dependency to avoid relying on bundlers automatic node globals injection.

Context: https://github.com/ipfs/js-ipfs/issues/2924